### PR TITLE
Updated Adafruit_I2C.py library to work with Raspberry Pi 2

### DIFF
--- a/Adafruit_I2C.py
+++ b/Adafruit_I2C.py
@@ -1,27 +1,31 @@
 #!/usr/bin/python
-
-try:
-  import smbus
-except Exception, err:
-  print err
-  pass
+import re
+import smbus
 
 # ===========================================================================
 # Adafruit_I2C Class
 # ===========================================================================
 
-class Adafruit_I2C :
+class Adafruit_I2C(object):
 
   @staticmethod
   def getPiRevision():
     "Gets the version number of the Raspberry Pi board"
-    # Courtesy quick2wire-python-api
-    # https://github.com/quick2wire/quick2wire-python-api
+    # Revision list available at: http://elinux.org/RPi_HardwareHistory#Board_Revision_History
     try:
-      with open('/proc/cpuinfo','r') as f:
-        for line in f:
-          if line.startswith('Revision'):
-            return 1 if line.rstrip()[-1] in ['1','2'] else 2
+      with open('/proc/cpuinfo', 'r') as infile:
+        for line in infile:
+          # Match a line of the form "Revision : 0002" while ignoring extra
+          # info in front of the revsion (like 1000 when the Pi was over-volted).
+          match = re.match('Revision\s+:\s+.*(\w{4})$', line)
+          if match and match.group(1) in ['0000', '0002', '0003']:
+            # Return revision 1 if revision ends with 0000, 0002 or 0003.
+            return 1
+          elif match:
+            # Assume revision 2 if revision ends with any other 4 chars.
+            return 2
+        # Couldn't find the revision, assume revision 0 like older code for compatibility.
+        return 0
     except:
       return 0
 
@@ -29,15 +33,14 @@ class Adafruit_I2C :
   def getPiI2CBusNumber():
     # Gets the I2C bus number /dev/i2c#
     return 1 if Adafruit_I2C.getPiRevision() > 1 else 0
- 
+
   def __init__(self, address, busnum=-1, debug=False):
     self.address = address
     # By default, the correct I2C bus is auto-detected using /proc/cpuinfo
     # Alternatively, you can hard-code the bus version below:
     # self.bus = smbus.SMBus(0); # Force I2C0 (early 256MB Pi's)
     # self.bus = smbus.SMBus(1); # Force I2C1 (512MB Pi's)
-    self.bus = smbus.SMBus(
-      busnum if busnum >= 0 else Adafruit_I2C.getPiI2CBusNumber())
+    self.bus = smbus.SMBus(busnum if busnum >= 0 else Adafruit_I2C.getPiI2CBusNumber())
     self.debug = debug
 
   def reverseByteOrder(self, data):
@@ -70,6 +73,15 @@ class Adafruit_I2C :
       if self.debug:
         print ("I2C: Wrote 0x%02X to register pair 0x%02X,0x%02X" %
          (value, reg, reg+1))
+    except IOError, err:
+      return self.errMsg()
+
+  def writeRaw8(self, value):
+    "Writes an 8-bit value on the bus"
+    try:
+      self.bus.write_byte(self.address, value)
+      if self.debug:
+        print "I2C: Wrote 0x%02X" % value
     except IOError, err:
       return self.errMsg()
 
@@ -118,29 +130,28 @@ class Adafruit_I2C :
     except IOError, err:
       return self.errMsg()
 
-  def readU16(self, reg):
+  def readU16(self, reg, little_endian=True):
     "Reads an unsigned 16-bit value from the I2C device"
     try:
-      result = self.bus.read_word_data(self.address, reg)
-      if self.debug:
-        print ("I2C: Device 0x%02X returned 0x%04X from reg 0x%02X" %
-         (self.address, result & 0xFFFF, reg))
+      result = self.bus.read_word_data(self.address,reg)
+      # Swap bytes if using big endian because read_word_data assumes little 
+      # endian on ARM (little endian) systems.
+      if not little_endian:
+        result = ((result << 8) & 0xFF00) + (result >> 8)
+      if (self.debug):
+        print "I2C: Device 0x%02X returned 0x%04X from reg 0x%02X" % (self.address, result & 0xFFFF, reg)
       return result
     except IOError, err:
       return self.errMsg()
 
-  def readS16(self, reg):
+  def readS16(self, reg, little_endian=True):
     "Reads a signed 16-bit value from the I2C device"
     try:
-      result = self.bus.read_word_data(self.address, reg)
+      result = self.readU16(reg,little_endian)
       if result > 32767: result -= 65536
-      if self.debug:
-        print ("I2C: Device 0x%02X returned 0x%04X from reg 0x%02X" %
-         (self.address, result & 0xFFFF, reg))
       return result
     except IOError, err:
       return self.errMsg()
-
 
 if __name__ == '__main__':
   try:


### PR DESCRIPTION
Updated Adafruit_I2C.py to the most current version. This update fixes the issue #3 :

`IOError: [Errno 2] No such file or directory`
